### PR TITLE
Request a LE certificate to traefik

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Launch `configure-module`, by setting the following parameters:
 - `mod_mam_status`: The XEP-0313: Message Archive Management (mod_mam). (true/false)
 - `shaper_normal`: Download speed limit in bytes/second for users, default is 500000
 - `shaper_fast`:  Download speed limit in bytes/second for admin users, default is 1000000
+- `purge_mnesia_database`: Enable the timer to purge the Mnesia database of old messages. (true/false)
+- `purge_mnesia_interval`: Remove old messages from Mnesia older than x days
+- `lets_encrypt`: Require a Let'sEncrypt valid certificate to Traefik. (true/false)
 
 Example:
 
@@ -58,7 +61,10 @@ Example:
     "shaper_normal": 500000,
     "shaper_fast": 1000000,
     "mod_http_upload_quota_status": true,
-    "mod_mam_status":true
+    "mod_mam_status":true,
+    "purge_mnesia_database": false,
+    "purge_mnesia_interval": "30"
+    "lets_encrypt": false,
     }
     EOF
 

--- a/imageroot/actions/configure-module/01hostname-validation
+++ b/imageroot/actions/configure-module/01hostname-validation
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import os
+import sys
+import json
+import agent
+import urllib.request
+import urllib.error
+import ssl
+
+agent.set_weight(os.path.basename(__file__), 0) # Validation step, no task progress at all
+
+# retrieve json data
+data = json.load(sys.stdin)
+
+# Setup default values
+hostname = data.get("hostname")
+# do not test if it is the same host
+oldHost = os.environ.get('EJABBERD_HOSTNAME','')
+
+if hostname != oldHost and agent.http_route_in_use(domain=hostname):
+    agent.set_status('validation-failed')
+    json.dump([{'field':'hostname','parameter':'hostname','value':hostname,'error':'domain_already_used_in_traefik'}],fp=sys.stdout)
+    sys.exit(2)

--- a/imageroot/actions/configure-module/20configure
+++ b/imageroot/actions/configure-module/20configure
@@ -27,6 +27,7 @@ shaper_fast = data.get("shaper_fast",1000000)
 mod_http_upload_quota_status = data.get("mod_http_upload_quota_status", False)
 mnesia_purge_interval = data.get("purge_mnesia_interval","30")
 mnesia_purge = data.get("purge_mnesia_database",False)
+le = data.get("lets_encrypt", False)
 
 # Talk with agent using file descriptor.
 # Setup configuration from user input.
@@ -41,3 +42,4 @@ agent.set_env("EJABBERD_SHAPER_FAST", shaper_fast)
 agent.set_env("EJABBERD_MOD_HTTP_UPLOAD_QUOTA_STATUS", mod_http_upload_quota_status)
 agent.set_env("EJABBERD_PURGE_MNESIA", mnesia_purge)
 agent.set_env("EJABBERD_PURGE_MNESIA_INTERVAL", mnesia_purge_interval)
+agent.set_env("TRAEFIK_LETS_ENCRYPT", le)

--- a/imageroot/actions/configure-module/40request-LE-certificate
+++ b/imageroot/actions/configure-module/40request-LE-certificate
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import sys
+import agent
+import agent.tasks
+import os
+
+
+agent_id = agent.resolve_agent_id('traefik@node')
+hostname = os.environ['EJABBERD_HOSTNAME']
+le = os.environ['TRAEFIK_LETS_ENCRYPT']
+
+if le:
+    agent.tasks.run_nowait(
+        agent_id=agent_id, # e.g. module/traefik1
+        action='set-certificate',
+        data={
+            "fqdn":hostname,
+            "sync": True,
+        },
+        parent='', # Run as a root task
+        extra={
+            'title': 'set-certificate',
+            'isNotificationHidden': False,
+        },
+    )

--- a/imageroot/bin/install-certificate
+++ b/imageroot/bin/install-certificate
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+if [[ -z "${EJABBERD_HOSTNAME}" ]]; then
+    exit 3 # Module is not fully configured, abort execution.
+fi
+
+mkdir -vp ${AGENT_STATE_DIR}/certificates/
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf ${tmpdir}' EXIT
+
+cd "${tmpdir}"
+umask 077
+
+# Override redis-exec "privileged=True"
+export REDIS_USER=default
+
+mtraefik=$(redis-exec GET "node/${NODE_ID}/default_instance/traefik")
+
+redis-exec HGET "module/${mtraefik}/certificate/${EJABBERD_HOSTNAME}" key | base64 -d > server.key
+redis-exec HGET "module/${mtraefik}/certificate/${EJABBERD_HOSTNAME}" cert | base64 -d > server.pem
+
+if [[ $(head -c 5 server.key) != '-----' || $(head -c 5 server.pem) != '-----' ]]; then
+    echo "[WARNING] ${service_image} certificate for ${EJABBERD_HOSTNAME} not found" 1>&2
+    exit 2
+fi
+
+# we want only one pem file all included
+cat server.key server.pem > ${AGENT_STATE_DIR}/certificates/ejabberd.pem
+
+# Important! preserve import-certificate exit code

--- a/imageroot/events/certificate-updated/00validate_event
+++ b/imageroot/events/certificate-updated/00validate_event
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import sys
+import agent
+import os
+
+event = json.load(sys.stdin)
+
+if str(event['node']) != os.environ['NODE_ID']:
+    print(agent.SD_DEBUG + "Event ignored: source is another node")
+    sys.exit(2)
+
+if event['domain']['main'] != os.environ['EJABBERD_HOSTNAME']:
+    print(agent.SD_DEBUG + "Event ignored: the certificate does not match our hostname")
+    sys.exit(3)

--- a/imageroot/events/certificate-updated/20install_certificate
+++ b/imageroot/events/certificate-updated/20install_certificate
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+if systemctl --user -q is-active ejabberd; then
+    install-certificate
+    systemctl --user restart ejabberd
+fi


### PR DESCRIPTION
Now we could request a certificate to traefik, once generated we trigger an event, we catch it and we restart ejabberd to cp the new certs

```
api-cli run configure-module --agent module/ejabberd1 --data - <<EOF
{
"hostname": "ejabberd2.nethserver.eu",
"ldap_domain": "nethserver.eu",
 "adminsList" : "admin@ad.rocky9-pve.org,administrator@rocky9-pve.org",
 "http_upload": true,
  "s2s" : true,
"shaper_normal": 500000,
 "shaper_fast": 1000000,
  "mod_http_upload_quota_status": true,
 "mod_mam_status":true,
 "purge_mnesia_database": false,
 "purge_mnesia_interval": "30",
 "lets_encrypt": true
}
```
