### PR TITLE
Wait after the creation of mnesia before to migrate

### DIFF
--- a/imageroot/actions/restore-module/70restore-backup
+++ b/imageroot/actions/restore-module/70restore-backup
@@ -14,6 +14,19 @@ if [[ ! -f ejabberd.backup ]]; then
     exit 0
 fi
 
+# we wait after the mnesia creation 
+# else we have an error during the migration
+i=0
+while ! podman exec -ti ejabberd bin/ejabberdctl status; do
+    let "i+=1"
+    if [[ $i -eq 5 ]]; then
+        echo "Ejabberd: Mnesia is not responding"
+        exit 1
+    fi
+    echo 'Ejabberd: Waiting mnesia database is up'
+    sleep 5
+done
+
 # cp the backup and load it
 podman cp ejabberd.backup ejabberd:database/ejabberd.backup
 podman exec ejabberd  bin/ejabberdctl install_fallback /home/ejabberd/database/ejabberd.backup

--- a/imageroot/actions/restore-module/70restore-backup
+++ b/imageroot/actions/restore-module/70restore-backup
@@ -18,11 +18,11 @@ fi
 # else we have an error during the migration
 i=0
 while ! podman exec -ti ejabberd bin/ejabberdctl status; do
-    let "i+=1"
-    if [[ $i -eq 5 ]]; then
+    if [[ $i -eq 10 ]]; then
         echo "Ejabberd: Mnesia is not responding"
         exit 1
     fi
+    let "i+=1"
     echo 'Ejabberd: Waiting mnesia database is up'
     sleep 5
 done


### PR DESCRIPTION
Ejabberd is a special beast we do not have docker-entrypoint like to load a database nor to execute a script to stop the container.
We start the container then we test if the container is up and we restore the databse. It needs a container fully up

https://github.com/processone/docker-ejabberd/blob/master/ecs/README.md