### PR TITLE
Add check for self signed certificate

### DIFF
--- a/imageroot/actions/configure-module/80start_services
+++ b/imageroot/actions/configure-module/80start_services
@@ -8,4 +8,4 @@
 # If the control reaches this step, the service can be enabled and started
 
 systemctl --user enable ejabberd.service
-systemctl --user -T reload-or-restart ejabberd.service
+systemctl --user -T restart ejabberd.service

--- a/imageroot/bin/install-certificate
+++ b/imageroot/bin/install-certificate
@@ -11,6 +11,10 @@ if [[ -z "${EJABBERD_HOSTNAME}" ]]; then
     exit 3 # Module is not fully configured, abort execution.
 fi
 
+if [[ "${TRAEFIK_LETS_ENCRYPT}" != 'True' ]]; then
+    exit 2 # We use a self signed certificate
+fi
+
 mkdir -vp ${AGENT_STATE_DIR}/certificates/
 
 tmpdir=$(mktemp -d)


### PR DESCRIPTION
This pull request adds a check for self signed certificates in the `install-certificate` script. If the `TRAEFIK_LETS_ENCRYPT` environment variable is not set to 'True', the script will exit with a status code of 2, indicating that a self signed certificate is being used. This check ensures that the script only proceeds if a valid Let's Encrypt certificate is being used.