### PR TITLE
Add a check for selfsigned certificate

### DIFF
--- a/imageroot/bin/install-certificate
+++ b/imageroot/bin/install-certificate
@@ -11,6 +11,10 @@ if [[ -z "${EJABBERD_HOSTNAME}" ]]; then
     exit 3 # Module is not fully configured, abort execution.
 fi
 
+if [[ "${TRAEFIK_LETS_ENCRYPT}" != 'True' ]]; then
+    exit 2 # We use a self signed certificate
+fi
+
 mkdir -vp ${AGENT_STATE_DIR}/certificates/
 
 tmpdir=$(mktemp -d)


### PR DESCRIPTION
Ejabberd manages itself the TLS, we a need a certificate inside the container, this fix intents to not use the LE Certificate if it has been managed by  TRAEFIK and if I require to use a selfsigned certificate

NethServer/dev#6781