### PR TITLE
Fix the Ejabberd first start

### DIFF
--- a/imageroot/actions/configure-module/15adjust-hostname-in-database
+++ b/imageroot/actions/configure-module/15adjust-hostname-in-database
@@ -8,7 +8,7 @@
 set -e
 
 # get the hostname from the json file
-/usr/bin/read -r hostname < <(jq -r '.hostname')
+hostname=$(cat /dev/stdin | jq -r '.hostname // empty')
 
 if [[ -z "$EJABBERD_HOSTNAME" ]];then
     /usr/bin/echo "First configuration of Ejabberd FQDN" >&2

--- a/imageroot/actions/configure-module/15adjust-hostname-in-database
+++ b/imageroot/actions/configure-module/15adjust-hostname-in-database
@@ -10,12 +10,12 @@ set -e
 # get the hostname from the json file
 /usr/bin/read -r hostname < <(jq -r '.hostname')
 
-if [[ -z $EJABBERD_HOSTNAME ]];then
+if [[ -z "$EJABBERD_HOSTNAME" ]];then
     /usr/bin/echo "First configuration of Ejabberd FQDN" >&2
     exit 0
 fi
 
-if [[ $hostname == $EJABBERD_HOSTNAME ]];then
+if [[ "$hostname" == "$EJABBERD_HOSTNAME" ]];then
     /usr/bin/echo "No need to modify Ejabberd FQDN" >&2
     exit 0
 fi

--- a/imageroot/actions/configure-module/15adjust-hostname-in-database
+++ b/imageroot/actions/configure-module/15adjust-hostname-in-database
@@ -12,12 +12,12 @@ set -e
 
 if [[ -z $EJABBERD_HOSTNAME ]];then
     /usr/bin/echo "First configuration of Ejabberd FQDN" >&2
-    /usr/bin/exit 0
+    exit 0
 fi
 
 if [[ $hostname == $EJABBERD_HOSTNAME ]];then
     /usr/bin/echo "No need to modify Ejabberd FQDN" >&2
-    /usr/bin/exit 0
+    exit 0
 fi
 
 /usr/bin/echo "We copy messages of old FQDN with new Ejabberd FQDN in MNESIA database" >&2

--- a/imageroot/bin/generate-certificate
+++ b/imageroot/bin/generate-certificate
@@ -15,7 +15,7 @@ csrtmp=$(mktemp csr.pem.XXXXXX)
 
 trap 'rm -f ${certtmp} ${keytmp} ${csrtmp}' EXIT
 
-umask 0133 # 644
+umask 022 # 644
 
 # we request csr
 openssl req -nodes -newkey rsa:2048 \

--- a/imageroot/bin/generate-certificate
+++ b/imageroot/bin/generate-certificate
@@ -15,7 +15,7 @@ csrtmp=$(mktemp csr.pem.XXXXXX)
 
 trap 'rm -f ${certtmp} ${keytmp} ${csrtmp}' EXIT
 
-umask 0077
+umask 0133 # 644
 
 # we request csr
 openssl req -nodes -newkey rsa:2048 \

--- a/imageroot/bin/install-certificate
+++ b/imageroot/bin/install-certificate
@@ -17,7 +17,7 @@ tmpdir=$(mktemp -d)
 trap 'rm -rf ${tmpdir}' EXIT
 
 cd "${tmpdir}"
-umask 077
+umask 133 # 644
 
 # Override redis-exec "privileged=True"
 export REDIS_USER=default

--- a/imageroot/bin/install-certificate
+++ b/imageroot/bin/install-certificate
@@ -17,7 +17,7 @@ tmpdir=$(mktemp -d)
 trap 'rm -rf ${tmpdir}' EXIT
 
 cd "${tmpdir}"
-umask 133 # 644
+umask 022 # 644
 
 # Override redis-exec "privileged=True"
 export REDIS_USER=default

--- a/imageroot/systemd/user/ejabberd.service
+++ b/imageroot/systemd/user/ejabberd.service
@@ -23,9 +23,9 @@ ExecStartPre=-runagent expand-configuration
 ExecStartPre=-runagent install-certificate
 ExecStartPre=bash -c "while [ ! -f certificates/ejabberd.pem ]; do sleep 1; done"
 ExecStartPre=bash -c "while [ ! -f certificates/dh.pem ]; do sleep 1; done"
-ExecStartPost=bash -c "while ! /usr/bin/podman exec ejabberd bin/ejabberdctl status; do sleep 1 ; done"
 ExecStartPost=/usr/bin/podman  cp certificates/ejabberd.pem ejabberd:conf/ejabberd.pem
 ExecStartPost=/usr/bin/podman  cp certificates/dh.pem ejabberd:conf/dh.pem
+ExecStartPost=bash -c "while ! /usr/bin/podman exec ejabberd bin/ejabberdctl status; do sleep 1 ; done"
 ExecStart=/usr/bin/podman run \
     --detach \
     --hostname=localhost \

--- a/imageroot/systemd/user/ejabberd.service
+++ b/imageroot/systemd/user/ejabberd.service
@@ -23,8 +23,6 @@ ExecStartPre=-runagent expand-configuration
 ExecStartPre=-runagent install-certificate
 ExecStartPre=bash -c "while [ ! -f certificates/ejabberd.pem ]; do sleep 1; done"
 ExecStartPre=bash -c "while [ ! -f certificates/dh.pem ]; do sleep 1; done"
-ExecStartPost=/usr/bin/podman  cp certificates/ejabberd.pem ejabberd:conf/ejabberd.pem
-ExecStartPost=/usr/bin/podman  cp certificates/dh.pem ejabberd:conf/dh.pem
 ExecStartPost=bash -c "while ! /usr/bin/podman exec ejabberd bin/ejabberdctl status; do sleep 1 ; done"
 ExecStart=/usr/bin/podman run \
     --detach \
@@ -37,6 +35,7 @@ ExecStart=/usr/bin/podman run \
     --volume=database:/home/ejabberd/database:Z \
     --volume=./config/ejabberd.yml:/home/ejabberd/conf/ejabberd.yml:Z \
     --volume=upload:/home/ejabberd/upload:Z \
+    --volume=./certificates:/home/ejabberd/certificates:Z \
     --init \
     --image-volume=ignore \
     ${ECS_IMAGE}
@@ -46,8 +45,7 @@ ExecReload=-runagent expand-configuration
 ExecReload=-runagent install-certificate
 ExecReload=bash -c "while [ ! -f certificates/ejabberd.pem ]; do sleep 1; done"
 ExecReload=bash -c "while [ ! -f certificates/dh.pem ]; do sleep 1; done"
-ExecReload=/usr/bin/podman  cp certificates/ejabberd.pem ejabberd:conf/ejabberd.pem
-ExecReload=/usr/bin/podman  cp certificates/dh.pem ejabberd:conf/dh.pem
+ExecReload=bash -c "while ! /usr/bin/podman exec ejabberd bin/ejabberdctl status; do sleep 1 ; done"
 ExecReload=runagent /usr/bin/podman exec \
     --env-file=environment \
     --env-file=discovery.env \

--- a/imageroot/templates/ejabberd.yml
+++ b/imageroot/templates/ejabberd.yml
@@ -10,7 +10,7 @@ hosts:
 #
 
 define_macro:
-  'CERTFILE': "/home/ejabberd/conf/ejabberd.pem"
+  'CERTFILE': "/home/ejabberd/certificates/ejabberd.pem"
   'TLSOPTS':
     - "no_sslv3"
     - "no_tlsv1"
@@ -37,7 +37,7 @@ listen:
     shaper: c2s_shaper
     access: c2s
     ciphers: 'CIPHERS'
-    dhfile: "/home/ejabberd/conf/dh.pem"
+    dhfile: "/home/ejabberd/certificates/dh.pem"
   - 
     port: 5223
     ip: "::"
@@ -48,7 +48,7 @@ listen:
     protocol_options: 'TLSOPTS'
     max_stanza_size: 65536
     ciphers: 'CIPHERS'
-    dhfile: "/home/ejabberd/conf/dh.pem"
+    dhfile: "/home/ejabberd/certificates/dh.pem"
   - 
     port: 5280
     ip: "::"
@@ -64,7 +64,7 @@ listen:
     captcha: false
     protocol_options: 'TLSOPTS'
     ciphers: 'CIPHERS'
-    dhfile: "/home/ejabberd/conf/dh.pem"
+    dhfile: "/home/ejabberd/certificates/dh.pem"
 {%if s2s %}
   - 
     port: 5269
@@ -74,7 +74,7 @@ listen:
     shaper: s2s_shaper
     protocol_options: 'TLSOPTS'
     ciphers: 'CIPHERS'
-    dhfile: "/home/ejabberd/conf/dh.pem"
+    dhfile: "/home/ejabberd/certificates/dh.pem"
 {% endif %}
 {%if http_upload %}
   - 
@@ -84,7 +84,7 @@ listen:
     tls: true
     protocol_options: 'TLSOPTS'
     ciphers: 'CIPHERS'
-    dhfile: "/home/ejabberd/conf/dh.pem"
+    dhfile: "/home/ejabberd/certificates/dh.pem"
     request_handlers:
         "/upload": mod_http_upload
 {% endif %}

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -24,7 +24,7 @@
     "title": "Settings",
     "configure_instance": "Configure {instance}",
     "hostname": "Ejabberd domain (FQDN)",
-    "hostname_placeholder": "domain.com",
+    "hostname_placeholder": "example.com",
     "hostname_must_be_relevant_for_user_authentication": "This is the domain used for user authentication, i.e. user@domain.com",
     "ldap_domain" : "LDAP user domain",
     "choose_the_ldap_domain_to_use": "Choose the LDAP domain used for user authentication",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -24,7 +24,7 @@
     "title": "Settings",
     "configure_instance": "Configure {instance}",
     "hostname": "Ejabberd domain (FQDN)",
-    "hostname_placeholder": "Enter Ejabberd domain: domain.com",
+    "hostname_placeholder": "domain.com",
     "hostname_must_be_relevant_for_user_authentication": "This is the domain used for user authentication, i.e. user@domain.com",
     "ldap_domain" : "LDAP user domain",
     "choose_the_ldap_domain_to_use": "Choose the LDAP domain used for user authentication",


### PR DESCRIPTION
Fix the first start of ejabberd

- Fix the test that prevented to start ejabberd due to the lack of certificate
- Change the permission of the certificate to 644 that allow to read the certificate
- Change a string in FQDN placeholder
- Change the path of certificate in template
- Change the way how to read from stdin and protect variables by `"`


https://github.com/NethServer/dev/issues/6781