### PR TITLE
Add hostname retrieval and fqdn field to configuration

### DIFF
--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -45,5 +45,8 @@ config["purge_mnesia_interval"] = int(os.getenv("EJABBERD_PURGE_MNESIA_INTERVAL"
 config["purge_httpd_upload_interval"] = int(os.getenv("EJABBERD_PURGE_HTTPD_UPLOAD_INTERVAL",30))
 config["webadmin"] = os.getenv("EJABBERD_WEBADMIN",'') == "True"
 
+# Find the hostname of the node
+config["fqdn"] = agent.get_hostname()
+
 # Dump the configuration to stdout
 json.dump(config, fp=sys.stdout)

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -336,6 +336,7 @@ export default {
       purge_mnesia_interval: "30",
       purge_httpd_upload_interval: "31",
       webadmin: false,
+      fqdn:"",
       loading: {
         getConfiguration: false,
         configureModule: false,
@@ -377,7 +378,7 @@ export default {
   },
   methods: {
     goToEjabberdWebAdmin(e) {
-      window.open(`https://${this.hostname}` + ":5280/admin/", "_blank");
+      window.open(`https://${this.fqdn}` + ":5280/admin/", "_blank");
       e.preventDefault();
     },
     async getConfiguration() {
@@ -440,6 +441,7 @@ export default {
         config.purge_httpd_upload_interval
       );
       this.webadmin = config.webadmin;
+      this.fqdn = config.fqdn;
       // force to reload value after dom update
       this.$nextTick(() => {
         this.ldap_domain = config.ldap_domain;


### PR DESCRIPTION
This pull request adds the functionality to retrieve the hostname of the node and includes a new field "fqdn" in the configuration. The fqdn field is used in the goToEjabberdWebAdmin method to open the Ejabberd Web Admin interface. This PR also includes necessary changes in the Settings.vue file to handle the new fqdn field.