### PR TITLE
Generate DH parameters and preserve permission

### DIFF
--- a/imageroot/bin/generate-dhpem
+++ b/imageroot/bin/generate-dhpem
@@ -19,4 +19,3 @@ openssl dhparam -out "${dhtmp}" 2048
 # we want preserve umask
 cat "${dhtmp}" > certificates/dh.pem
 
-# Important! preserve exit code

--- a/imageroot/bin/generate-dhpem
+++ b/imageroot/bin/generate-dhpem
@@ -6,8 +6,17 @@
 #
 
 set -e
+# build directory structure
 mkdir -vp certificates
+
+# create a temporary file
 dhtmp=$(mktemp dh.pem.XXXXXX)
 trap 'rm -f ${dhtmp}' EXIT
+
+umask 022 # 644
 openssl dhparam -out "${dhtmp}" 2048
-mv -v "${dhtmp}" certificates/dh.pem
+
+# we want preserve umask
+cat "${dhtmp}" > certificates/dh.pem
+
+# Important! preserve exit code


### PR DESCRIPTION
This pull request adds a new script, `generate-dhpem`, which generates Diffie-Hellman (DH) parameters and preserves the file permissions. The script creates a directory structure, `certificates`, and generates a temporary DH parameter file. The file is then moved to the `certificates` directory while preserving the original file permissions. This change ensures that the DH parameters are generated correctly and that the file permissions are maintained.

https://github.com/NethServer/dev/issues/6781