### PR TITLE
Update admin login tips in translation.json

### DIFF
--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -39,7 +39,7 @@
     "bad_email_address": "Please enter user@domain. Invalid administrator:",
     "processing": "Processing...",
     "required": "Required",
-    "admin_login_tips": "If enabled, Web Admin page is available at http://domain.com:5280. An HTTP route must be done manually",
+    "admin_login_tips": "If enabled, Web Admin page is available at http://domain.com:5280. An HTTP route to '/admin' must be done manually",
     "Enable_federation_s2s": "Enable federation (S2S)",
     "Enable_message_archive_management_mod_mam": "Enable Message Archive Management (mod_mam)",
     "Enable_file_upload_mod_http_upload": "Enable file upload (mod_http_upload)",


### PR DESCRIPTION
This pull request updates the admin login tips in the translation.json file. Previously, the tips mentioned that an HTTP route must be done manually, but now it specifies that an HTTP route to '/admin' must be done manually. This change provides clearer instructions for enabling the Web Admin page.

Fixes #1234