### PR TITLE
Update hostname validation and messages

### DIFF
--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -42,7 +42,8 @@
         "hostname": {
             "type": "string",
             "description": "Host name for the application, like 'ejabberd.org'",
-            "format": "idn-hostname"
+            "format": "hostname",
+            "pattern": "\\."
         },
         "lets_encrypt": {
             "type": "boolean",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -53,7 +53,9 @@
     "save": "Save",
     "specify_duration": "Specify duration",
     "days": "Days",
-    "never": "Never clean"
+    "never": "Never clean",
+    "hostname_pattern": "Must be a valid fully qualified domain name",
+    "hostname_format": "Must be a valid fully qualified domain name"
   },
   "about": {
     "title": "About"


### PR DESCRIPTION
This pull request updates the hostname validation in the `validate-input.json` file to use the `hostname` format and adds a pattern to enforce a fully qualified domain name. It also adds validation messages for the hostname in the `translation.json` file.

https://github.com/NethServer/dev/issues/6853