### PR TITLE
Upgrade ejabberd to 24.02

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -39,7 +39,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=traefik@node:certadm node:fwadm cluster:accountconsumer" \
     --label="org.nethserver.tcp-ports-demand=0" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=docker.io/ejabberd/ecs:23.10" \
+    --label="org.nethserver.images=docker.io/ejabberd/ecs:24.02" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"


### PR DESCRIPTION
Upgrade ejabberd to 24.02

- we need to test the migration from NS7 to NS8 : migration from ns7 version to ns8 version OK
- webtop is not broken :  webtop can send messages between users OK

https://github.com/NethServer/dev/issues/6931