### PR TITLE
chore: Update renovate.json configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,55 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:base"
+    ],
+    "ignorePaths": [
+        "**/ui/**"
+    ],
+    "regexManagers": [
+        {
+            "fileMatch": [
+                "build-images.sh"
+            ],
+            "matchStrings": [
+                "docker\\.io\/node:(?<currentValue>[^\\s]+)"
+            ],
+            "depNameTemplate": "node",
+            "datasourceTemplate": "docker"
+        },
+        {
+            "fileMatch": [
+                "build-images.sh"
+            ],
+            "matchStrings": [
+                "docker\\.io\/ejabberd\/ecs:(?<currentValue>[^\\s]+)"
+            ],
+            "depNameTemplate": "ejabberd",
+            "datasourceTemplate": "docker"
+        },
+        {
+            "fileMatch": [
+                "test-module.sh"
+            ],
+            "matchStrings": [
+                "ghcr\\.io/marketsquare/robotframework-browser/rfbrowser-stable:(?<currentValue>[^\\s]+)"
+            ],
+            "depNameTemplate": "MarketSquare/robotframework-browser",
+            "datasourceTemplate": "github-releases"
+        }
+    ],
+    "packageRules": [
+        {
+            "matchPackageNames": [
+                "node"
+            ],
+            "allowedVersions": "<= 18"
+        },
+        {
+            "matchPackageNames": [
+                "ghcr.io/marketsquare/robotframework-browser/rfbrowser-stable"
+            ],
+            "allowedVersions": "<= 10.0"
+        }
+    ]
+}


### PR DESCRIPTION
Add regex managers and package rules to renovate.json for managing dependencies. This configuration file includes match strings, dep name templates, and datasource templates for different files. It also specifies allowed versions for certain packages.

