### PR TITLE
Update Docker image match string in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,7 @@
                 "build-images.sh"
             ],
             "matchStrings": [
-                "docker\\.io\/ejabberd\/ecs:(?<currentValue>[^\\s]+)"
+                "docker\\.io\/ejabberd\/ecs:(?<currentValue>[^\\s]+)\""
             ],
             "depNameTemplate": "ejabberd/ecs",
             "datasourceTemplate": "docker"


### PR DESCRIPTION
This pull request updates the Docker image match string in the `renovate.json` file. The previous match string was missing a closing quote, which has been added in this update.