### PR TITLE
Ignore renovate branches and tags in GitHub workflows

### DIFF
--- a/.github/workflows/build-apidoc.yml
+++ b/.github/workflows/build-apidoc.yml
@@ -6,6 +6,10 @@ on:
       - '**/validate-input.json'
       - '**/validate-output.json'
       - '**/validator-definitions.json'
+    branches-ignore:
+      - 'renovate/**'
+    tags:
+      - "**"
 
 jobs:
   build-apidoc:

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -2,6 +2,11 @@ name: "Publish images"
 
 on:
   push:
+    branches-ignore:
+      - 'renovate/**'
+    tags:
+      - "**"
+
 
 permissions:
   packages: write


### PR DESCRIPTION
This pull request updates the GitHub workflows to ignore renovate branches and tags. This ensures that the workflows are not triggered for renovate-related changes.