### PR TITLE
Update ejabberd.yml with webadmin commands permissions

### DIFF
--- a/imageroot/templates/ejabberd.yml
+++ b/imageroot/templates/ejabberd.yml
@@ -168,7 +168,15 @@ api_permissions:
     what:
       - "status"
       - "connected_users_number"
-
+  "webadmin commands":
+    from:
+      - ejabberd_web_admin
+    who:
+      access:
+        allow:
+          - acl: admin
+    what:
+      - "*"
 
 
 acl:


### PR DESCRIPTION
This pull request updates the ejabberd.yml file to include permissions for webadmin commands. The "webadmin commands" section has been added to the api_permissions section, allowing users with the "admin" ACL to access all commands.

https://github.com/NethServer/dev/issues/7008



the documentation part comes from https://www.process-one.net/blog/ejabberd-24-06/#webadmin-config

This new api permission has been introduced with 24.06