### PR TITLE
Limit ejabberd to one module per node

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -37,6 +37,7 @@ buildah add "${container}" ui/dist /ui
 # Setup the entrypoint, ask to reserve one TCP port with the label and set a rootless container
 buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=traefik@node:certadm node:fwadm cluster:accountconsumer" \
+    --label="org.nethserver.max-per-node=1" \
     --label="org.nethserver.tcp-ports-demand=0" \
     --label="org.nethserver.rootfull=0" \
     --label="org.nethserver.images=docker.io/ejabberd/ecs:24.07" \


### PR DESCRIPTION
With the new option we can set in the software center to use only one module per node due to the TCP allocated port restriction

Refs https://github.com/NethServer/dev/issues/6955