### PR TITLE
Refactor tooltip rendering and update dependencies

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@carbon/icons-vue": "^10.37.0",
     "@carbon/vue": "^2.40.0",
-    "@nethserver/ns8-ui-lib": "^0.1.20",
+    "@nethserver/ns8-ui-lib": "^1.1.4",
     "await-to-js": "^3.0.0",
     "axios": "^0.21.2",
     "carbon-components": "^10.41.0",

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -42,13 +42,7 @@
               tooltipDirection="right"
             >
               <template slot="tooltip">
-                <div
-                  v-html="
-                    $t(
-                      'settings.hostname_must_be_relevant_for_user_authentication'
-                    )
-                  "
-                ></div>
+                <div>{{ $t('settings.hostname_must_be_relevant_for_user_authentication') }}</div>
               </template>
             </NsTextInput>
             <NsComboBox
@@ -100,7 +94,7 @@
                     ref="webadmin"
                   >
                     <template slot="tooltip">
-                      <span v-html="$t('settings.admin_login_tips')"></span>
+                      <span>{{ $t('settings.admin_login_tips') }}</span>
                     </template>
                     <template slot="text-left">{{
                       $t("settings.disabled")

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -42,7 +42,13 @@
               tooltipDirection="right"
             >
               <template slot="tooltip">
-                <div>{{ $t('settings.hostname_must_be_relevant_for_user_authentication') }}</div>
+                <div>
+                  {{
+                    $t(
+                      "settings.hostname_must_be_relevant_for_user_authentication"
+                    )
+                  }}
+                </div>
               </template>
             </NsTextInput>
             <NsComboBox
@@ -94,7 +100,7 @@
                     ref="webadmin"
                   >
                     <template slot="tooltip">
-                      <span>{{ $t('settings.admin_login_tips') }}</span>
+                      <span>{{ $t("settings.admin_login_tips") }}</span>
                     </template>
                     <template slot="text-left">{{
                       $t("settings.disabled")
@@ -108,7 +114,9 @@
                       kind="ghost"
                       class="mg-left"
                       :icon="Launch20"
-                      :disabled="loading.getConfiguration || loading.configureModule"
+                      :disabled="
+                        loading.getConfiguration || loading.configureModule
+                      "
                       @click="goToEjabberdWebAdmin"
                     >
                       {{ $t("settings.open_ejabberd_webapp") }}
@@ -483,7 +491,8 @@ export default {
       }
       //validate normal speed < fast speed
       if (parseInt(this.shaper_normal) > parseInt(this.shaper_fast)) {
-        this.error.shaper_normal = "error.shaper_normal_must_be_inferior_to_shaper_fast";
+        this.error.shaper_normal =
+          "error.shaper_normal_must_be_inferior_to_shaper_fast";
         this.shaper_normal = this.shaper_fast;
         if (isValidationOk) {
           this.focusElement("shaper_normal");

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1012,10 +1012,10 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@nethserver/ns8-ui-lib@^0.1.20":
-  version "0.1.20"
-  resolved "https://registry.yarnpkg.com/@nethserver/ns8-ui-lib/-/ns8-ui-lib-0.1.20.tgz#375e662fec47d7d4a29e33b349636707b6ac777a"
-  integrity sha512-xRak1AS4lXU6+r5CJMYzux4gHI15qqz9Gu2qphOSW7jT13u6eUnp3NtYTjuDGv9P6Up0BLbK3VCjEBlHLi+BZQ==
+"@nethserver/ns8-ui-lib@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.npmmirror.com/@nethserver/ns8-ui-lib/-/ns8-ui-lib-1.1.4.tgz#6e8a47356c43773527c2d410e907c3dbe41326e2"
+  integrity sha512-z5lpixFPFlhBejMIYOFG6+YS74wcoppg1bat3WM1HTVo5gmpE3GVMOOIz+A2ThO9S/4ecWs6LG/GT/syQI2k5A==
   dependencies:
     "@rollup/plugin-json" "^4.1.0"
     core-js "^3.15.2"


### PR DESCRIPTION
Refactored the tooltip rendering in Settings.vue to use template literals instead of v-html for better security. Also updated the "@nethserver/ns8-ui-lib" dependency to version 1.1.4 in the package.json and yarn.lock files.