### PR TITLE
Fix user-domain-changed event

### DIFF
--- a/imageroot/events/user-domain-changed/20configure_ldap
+++ b/imageroot/events/user-domain-changed/20configure_ldap
@@ -15,7 +15,7 @@ event = json.load(sys.stdin)
 if event.get('domain') != os.getenv('EJABBERD_LDAP_DOMAIN'):
     exit(0)
 
-if 'node' in event and str(event['node']) != os.getenv('NODE_ID'):
+if 'node_id' in event and str(event['node_id']) != os.getenv('NODE_ID'):
     exit(0) # ignore event if the source is not in our node
 
 agent.run_helper('systemctl', '--user', '-T', 'try-reload-or-restart', 'ejabberd.service').check_returncode()

--- a/imageroot/events/user-domain-changed/20configure_ldap
+++ b/imageroot/events/user-domain-changed/20configure_ldap
@@ -15,7 +15,4 @@ event = json.load(sys.stdin)
 if event.get('domain') != os.getenv('EJABBERD_LDAP_DOMAIN'):
     exit(0)
 
-if 'node_id' in event and str(event['node_id']) != os.getenv('NODE_ID'):
-    exit(0) # ignore event if the source is not in our node
-
 agent.run_helper('systemctl', '--user', '-T', 'try-restart', 'ejabberd.service').check_returncode()

--- a/imageroot/events/user-domain-changed/20configure_ldap
+++ b/imageroot/events/user-domain-changed/20configure_ldap
@@ -18,4 +18,4 @@ if event.get('domain') != os.getenv('EJABBERD_LDAP_DOMAIN'):
 if 'node_id' in event and str(event['node_id']) != os.getenv('NODE_ID'):
     exit(0) # ignore event if the source is not in our node
 
-agent.run_helper('systemctl', '--user', '-T', 'try-reload-or-restart', 'ejabberd.service').check_returncode()
+agent.run_helper('systemctl', '--user', '-T', 'try-restart', 'ejabberd.service').check_returncode()


### PR DESCRIPTION
Update the event handling logic to check for 'node_id' instead of 'node' to ensure proper event processing.

Ejabberd with the change of ldap, must be restarted, a reload is not enough

https://github.com/NethServer/dev/issues/7103