### PR TITLE
Set default_version for mod_http_api to 2

### DIFF
--- a/imageroot/templates/ejabberd.yml
+++ b/imageroot/templates/ejabberd.yml
@@ -268,7 +268,8 @@ modules:
   mod_version: {}
   mod_stream_mgmt: {}
   mod_s2s_dialback: {}
-  mod_http_api: {}
+  mod_http_api:
+    default_version: 2
 {%if http_upload %}
   mod_http_upload:
     docroot: "/home/ejabberd/upload/"


### PR DESCRIPTION
Configure the default version for the mod_http_api module to ensure compatibility with webtop

https://github.com/NethServer/dev/issues/7233

it seems that webtop is compatible with version 3, so maybe this PR is not needed, I can connect to xmpp from webtop, send a message, send a file, retrieve messages with notification. all of these  with the version 3, so without the fix of this PR

for reminders on mod_http_api

The mod_http_api in ejabberd provides a RESTful HTTP API for managing the server via HTTP/HTTPS requests.

Key Features:

- User Management: Add, delete, and modify users; change passwords.
- Groups and Roles: Create groups, add or remove members.
- Messages: Send instant messages and retrieve chat history.
- Session Control: List active sessions and disconnect users.
- Monitoring and Stats: View server status and usage statistics.
- Module Management: Enable/disable modules and reload configuration.

What do we do, we try to go to V3 and do  not merge this PR ?


question asked to [mattermost webtop channel](https://mattermost.nethesis.it/webtop/pl/g8ctjsxmnpgh7k98i9hfpqm4za)