### PR TITLE
fix(ldap): use displayname with openldap

### DIFF
--- a/imageroot/templates/ejabberd.yml
+++ b/imageroot/templates/ejabberd.yml
@@ -285,6 +285,7 @@ modules:
     ldap_groupattr: "cn"
     ldap_groupdesc: "o"
     ldap_useruid: "uid"
+    ldap_userdesc: "displayName"
     ldap_ufilter: "(uid=%u)"
     ldap_rfilter: "(objectClass=inetOrgPerson)"
     ldap_memberattr: "uid"


### PR DESCRIPTION
With webtop we do not use displayname

https://github.com/NethServer/dev/issues/7311

tested with openldap
![image](https://github.com/user-attachments/assets/e454cf7c-86c0-441e-ad72-7d15728dd135)
