### PR TITLE
Update url of documentation

### DIFF
--- a/ui/public/metadata.json
+++ b/ui/public/metadata.json
@@ -12,7 +12,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://docs.ejabberd.im/",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/ejabberd.html",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/NethServer/ns8-ejabberd"
   },


### PR DESCRIPTION
This pull request updates the documentation URL in the `ui/public/metadata.json` file to point to the latest and more specific documentation for `ejabberd` hosted on the NethServer website.

* Updated the `documentation_url` in `ui/public/metadata.json` to `https://docs.nethserver.org/projects/ns8/en/latest/ejabberd.html` to provide a more accurate and up-to-date resource for users.

https://github.com/NethServer/dev/issues/7399