### PR TITLE
fix(systemd): replace %S with %E in unit files

### DIFF
--- a/imageroot/systemd/user/dhgen.service
+++ b/imageroot/systemd/user/dhgen.service
@@ -5,5 +5,5 @@ Description=Diffie-Hellman group generator
 Type=oneshot
 ExecStart=runagent generate-dhpem
 ExecStart=-systemctl --user reload ejabberd.service
-WorkingDirectory=%S/state
+WorkingDirectory=%E/state
 SyslogIdentifier=%N

--- a/imageroot/systemd/user/ejabberd.service
+++ b/imageroot/systemd/user/ejabberd.service
@@ -14,9 +14,9 @@ After=get-certificate.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-EnvironmentFile=-%S/state/discovery.env
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+EnvironmentFile=-%E/state/discovery.env
+WorkingDirectory=%E/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/ejabberd.pid %t/ejabberd.ctr-id
 ExecStartPre=-runagent discover-ldap

--- a/imageroot/systemd/user/get-certificate.service
+++ b/imageroot/systemd/user/get-certificate.service
@@ -3,8 +3,8 @@ Description=Get TLS certificate from Traefik
 
 [Service]
 Type=oneshot
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 SyslogIdentifier=%N
 ExecStart=-mkdir -vp certificates
 ExecStart=-runagent get-certificate --cert-file=certificates/server.pem --key-file=certificates/server.key $EJABBERD_HOSTNAME

--- a/imageroot/systemd/user/purge-mnesia-database.service
+++ b/imageroot/systemd/user/purge-mnesia-database.service
@@ -6,5 +6,5 @@ Requisite=ejabberd.service
 [Service]
 Type=oneshot
 ExecStart=runagent purge-mnesia
-WorkingDirectory=%S/state
+WorkingDirectory=%E/state
 SyslogIdentifier=%u/%N


### PR DESCRIPTION
## Summary
- Newer systemd releases (Rocky Linux 9.8+, Debian 13) changed the `%S` specifier to expand to `~/.local/state` instead of `~/.config`, breaking units that relied on the old behavior to reference the config/state directory.
- Replaced `%S` with `%E` across all affected systemd user unit files. `%E` expands to `~/.config` on both old and new systemd, making the units forward-compatible.

Related: NethServer/dev#8029

## Test plan
- [ ] Verify units still parse (`systemd-analyze verify`) on a test node
- [ ] Confirm services start correctly on both an old (Rocky 9.x pre-9.8) and new (Rocky 9.8+/Debian 13) systemd host